### PR TITLE
extend CAS restletIntegration function to support dynamic config params

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,6 +150,16 @@ ConnectCas.prototype.core = function() {
       proxyOptions.targetService = targetService;
 
       if (options.paths.proxyCallback) {
+        var restletIntegrateParams;
+        if (matchedRestletIntegrateRule) {
+          if (typeof options.restletIntegration[matchedRestletIntegrateRule].params === 'function') {
+            logger.info('Match restlet integration rule and using aync manner, whitch using function to return `object`, to get restlet integration params: ', matchedRestletIntegrateRule);
+            restletIntegrateParams = options.restletIntegration[matchedRestletIntegrateRule].params(req);
+          } else {
+            logger.info('Match restlet integration rule and using default manner, whitch just directly return `object`, to get restlet integration params: ', matchedRestletIntegrateRule);
+            restletIntegrateParams = options.restletIntegration[matchedRestletIntegrateRule].params;
+          }
+        }
         matchedRestletIntegrateRule ? getProxyTicketThroughRestletReq.call(that, req, targetService, {
           name: matchedRestletIntegrateRule,
           params: options.restletIntegration[matchedRestletIntegrateRule].params


### PR DESCRIPTION
扩张CAS 的 API login 登录方式（restletIntegration），使其支持动态配置restlet integration params