### PR TITLE
Decode Cas SLO response

### DIFF
--- a/lib/slo.js
+++ b/lib/slo.js
@@ -28,7 +28,7 @@ module.exports = function(req, callback, options) {
     body += chunk;
   });
   req.on('end', function() {
-    if (!/<samlp:SessionIndex>(.*)<\/samlp:SessionIndex>/.exec(body)) {
+    if (!/<samlp:SessionIndex>(.*)<\/samlp:SessionIndex>/.exec(decodeURIComponent(body))) {
       logger.info('Slo request receive, but body content is not valid');
 
       // 响应已经end了, 没next了


### PR DESCRIPTION
Sometimes the SLO response from Cas is in URIEncoded format. Decoding it so that ST can be extracted.